### PR TITLE
FT-88077: Ruby 2.4 support

### DIFF
--- a/i18nema.gemspec
+++ b/i18nema.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.extensions = ['ext/i18nema/extconf.rb']
   s.files = %w(Rakefile README.md) + Dir['ext/**/*.{c,h,rb}'] + Dir['lib/**/*.rb'] + Dir['test/**/*.rb']
-  s.add_dependency('syck', '~> 1.0.0') unless RUBYONEX
+  s.add_dependency('syck', '~> 1.2.0') unless RUBYONEX
   s.add_dependency('i18n', '>= 0.5')
   s.add_development_dependency('rake-compiler', '~> 0.8.0')
 end


### PR DESCRIPTION
FR Task: [FT-88077](https://freshworks.freshrelease.com/ws/FT/tasks/FT-88077)

Error faced:

 ```
rubyext.c:1165:34: error: use of undeclared identifier 'rb_cBignum'

                if ( subclass == rb_cBignum )
```

This is happening because Ruby 2.4 unified [Fixnum and Bignum into Integer](https://bugs.ruby-lang.org/issues/12005)

So updated to syck 1.2.0 which provides Ruby 2.4 support

Verified changes here: https://github.com/ruby/syck/compare/v1.1.0...v1.2.0
I see it’s a reverse-compatible change(checks definition of RUBY_INTEGER_UNIFICATION and handles logic based on that):
https://github.com/ruby/syck/commit/3eda9dff1060f6d74fe426a16a7dfbe4dac33e1a?diff=split